### PR TITLE
Create chrome extension for quick replies

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,107 @@
+let floatingWindowId = null;
+
+async function createFloatingWindow() {
+  return new Promise((resolve) => {
+    chrome.windows.create(
+      {
+        url: chrome.runtime.getURL("popup.html"),
+        type: "popup",
+        width: 420,
+        height: 640,
+        top: 100,
+        left: 100,
+        focused: true,
+      },
+      (win) => {
+        if (!win) {
+          resolve(null);
+          return;
+        }
+        floatingWindowId = win.id;
+        // Essai best-effort pour activer Always-on-Top si l'API est disponible
+        try {
+          chrome.windows.update(
+            win.id,
+            { focused: true, drawAttention: false, alwaysOnTop: true },
+            () => {
+              void chrome.runtime.lastError;
+              resolve(win);
+            }
+          );
+        } catch (e) {
+          resolve(win);
+        }
+      }
+    );
+  });
+}
+
+async function toggleFloatingWindow() {
+  if (floatingWindowId) {
+    try {
+      const w = await chrome.windows.get(floatingWindowId, { populate: false });
+      if (w) {
+        await chrome.windows.update(floatingWindowId, { focused: true });
+        return;
+      }
+    } catch (e) {
+      floatingWindowId = null;
+    }
+  }
+  await createFloatingWindow();
+}
+
+chrome.windows.onRemoved.addListener((id) => {
+  if (id === floatingWindowId) {
+    floatingWindowId = null;
+  }
+});
+
+// Clic sur l'icône de l'extension : on privilégie le Side Panel si dispo
+chrome.action.onClicked.addListener(async (tab) => {
+  if (chrome.sidePanel && chrome.sidePanel.open) {
+    try {
+      if (chrome.sidePanel.setOptions) {
+        try {
+          await chrome.sidePanel.setOptions({
+            tabId: tab?.id,
+            path: "popup.html",
+            enabled: true,
+          });
+        } catch (e) {
+          // ignore
+        }
+      }
+      try {
+        if (tab?.id) {
+          await chrome.sidePanel.open({ tabId: tab.id });
+          return;
+        }
+      } catch (e) {
+        // fallback si open échoue
+      }
+    } catch (e) {
+      // fallback vers fenêtre flottante
+    }
+  }
+  await toggleFloatingWindow();
+});
+
+// Raccourci clavier
+chrome.commands?.onCommand?.addListener(async (command) => {
+  if (command === "toggle-quick-reply-window") {
+    await toggleFloatingWindow();
+  }
+});
+
+// Au moment de l'installation, configurer le comportement du panel si supporté
+chrome.runtime.onInstalled.addListener(async () => {
+  if (chrome.sidePanel && chrome.sidePanel.setPanelBehavior) {
+    try {
+      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+    } catch (e) {
+      // ignore
+    }
+  }
+});
+

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifest_version": 3,
+  "name": "Quick Reply Manager",
+  "version": "1.0.0",
+  "description": "Une extension pour gérer des réponses rapides dans une popup Always-on-Top.",
+  "permissions": ["storage", "windows", "sidePanel"],
+  "action": {
+    "default_title": "Quick Reply Manager"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "side_panel": {
+    "default_path": "popup.html"
+  },
+  "commands": {
+    "toggle-quick-reply-window": {
+      "suggested_key": {
+        "default": "Alt+Q"
+      },
+      "description": "Ouvrir/fermer la fenêtre flottante Quick Reply"
+    }
+  }
+}
+

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Quick Reply Manager</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="style.css" rel="stylesheet">
+  
+</head>
+<body>
+  <header class="header">
+    <div class="title">Quick Reply Manager</div>
+    <input id="searchInput" type="search" placeholder="Recherche par mot-clé..." aria-label="Recherche">
+  </header>
+
+  <section class="toolbar">
+    <label for="categorySelect">Catégorie:</label>
+    <select id="categorySelect"></select>
+    <div class="btn-group">
+      <button id="addCategoryBtn" class="btn">+ Catégorie</button>
+      <button id="editCategoryBtn" class="btn">Modifier</button>
+      <button id="deleteCategoryBtn" class="btn btn-danger">Supprimer</button>
+    </div>
+    <div class="spacer"></div>
+    <button id="addTemplateBtn" class="btn primary">+ Modèle</button>
+  </section>
+
+  <section id="searchResults" class="search-results hidden"></section>
+
+  <main class="main">
+    <aside class="list" id="templatesList"></aside>
+    <section class="viewer" id="templateViewer">
+      <div class="placeholder">Sélectionnez un modèle pour afficher le texte.</div>
+      <div class="viewer-content hidden">
+        <h3 id="viewerTitle"></h3>
+        <textarea id="viewerText" readonly></textarea>
+        <div class="viewer-actions">
+          <button id="copyBtn" class="btn primary">Copier</button>
+          <button id="editTemplateBtn" class="btn">Modifier</button>
+          <button id="deleteTemplateBtn" class="btn btn-danger">Supprimer</button>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <dialog id="categoryDialog">
+    <form method="dialog" id="categoryForm">
+      <h3 id="categoryDialogTitle">Nouvelle catégorie</h3>
+      <input type="text" id="categoryNameInput" placeholder="Nom de la catégorie" required>
+      <menu>
+        <button value="cancel">Annuler</button>
+        <button id="saveCategoryBtn" value="save" class="primary">Enregistrer</button>
+      </menu>
+    </form>
+  </dialog>
+
+  <dialog id="templateDialog">
+    <form method="dialog" id="templateForm">
+      <h3 id="templateDialogTitle">Nouveau modèle</h3>
+      <input type="text" id="templateTitleInput" placeholder="Titre du message" required>
+      <textarea id="templateTextInput" placeholder="Texte de réponse" required></textarea>
+      <menu>
+        <button value="cancel">Annuler</button>
+        <button id="saveTemplateBtn" value="save" class="primary">Enregistrer</button>
+      </menu>
+    </form>
+  </dialog>
+
+  <script type="module" src="popup.js"></script>
+</body>
+</html>
+

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,341 @@
+import { QRMStorage } from "./storage.js";
+
+const categorySelect = document.getElementById("categorySelect");
+const addCategoryBtn = document.getElementById("addCategoryBtn");
+const editCategoryBtn = document.getElementById("editCategoryBtn");
+const deleteCategoryBtn = document.getElementById("deleteCategoryBtn");
+const addTemplateBtn = document.getElementById("addTemplateBtn");
+const searchInput = document.getElementById("searchInput");
+const searchResults = document.getElementById("searchResults");
+
+const templatesList = document.getElementById("templatesList");
+const viewer = document.getElementById("templateViewer");
+const viewerTitle = document.getElementById("viewerTitle");
+const viewerText = document.getElementById("viewerText");
+const viewerCopyBtn = document.getElementById("copyBtn");
+const editTemplateBtn = document.getElementById("editTemplateBtn");
+const deleteTemplateBtn = document.getElementById("deleteTemplateBtn");
+
+const categoryDialog = document.getElementById("categoryDialog");
+const categoryForm = document.getElementById("categoryForm");
+const categoryDialogTitle = document.getElementById("categoryDialogTitle");
+const categoryNameInput = document.getElementById("categoryNameInput");
+
+const templateDialog = document.getElementById("templateDialog");
+const templateForm = document.getElementById("templateForm");
+const templateDialogTitle = document.getElementById("templateDialogTitle");
+const templateTitleInput = document.getElementById("templateTitleInput");
+const templateTextInput = document.getElementById("templateTextInput");
+
+let categories = [];
+let selectedCategoryId = null;
+let selectedTemplateId = null;
+
+async function init() {
+  categories = await QRMStorage.getCategories();
+  if (categories.length > 0) {
+    selectedCategoryId = categories[0].id;
+  }
+  renderCategories();
+  renderTemplates();
+  wireEvents();
+}
+
+function wireEvents() {
+  searchInput.addEventListener("input", handleSearchInput);
+
+  categorySelect.addEventListener("change", () => {
+    selectedCategoryId = categorySelect.value;
+    selectedTemplateId = null;
+    renderTemplates();
+    renderViewer(null);
+  });
+
+  addCategoryBtn.addEventListener("click", () => openCategoryDialog());
+  editCategoryBtn.addEventListener("click", () => openCategoryDialog(selectedCategoryId));
+  deleteCategoryBtn.addEventListener("click", async () => {
+    if (!selectedCategoryId) return;
+    if (!confirm("Supprimer cette catégorie ?")) return;
+    await QRMStorage.removeCategory(selectedCategoryId);
+    categories = await QRMStorage.getCategories();
+    selectedCategoryId = categories[0]?.id || null;
+    renderCategories();
+    renderTemplates();
+    renderViewer(null);
+  });
+
+  addTemplateBtn.addEventListener("click", () => openTemplateDialog());
+  viewerCopyBtn.addEventListener("click", copyCurrentTemplate);
+  editTemplateBtn.addEventListener("click", () => {
+    if (!selectedTemplateId) return;
+    openTemplateDialog(selectedTemplateId);
+  });
+  deleteTemplateBtn.addEventListener("click", async () => {
+    if (!selectedTemplateId) return;
+    if (!confirm("Supprimer ce modèle ?")) return;
+    await QRMStorage.removeTemplate(selectedCategoryId, selectedTemplateId);
+    categories = await QRMStorage.getCategories();
+    selectedTemplateId = null;
+    renderTemplates();
+    renderViewer(null);
+  });
+
+  // Synchroniser quand le stockage change
+  QRMStorage.onChanged(async () => {
+    categories = await QRMStorage.getCategories();
+    if (!categories.find((c) => c.id === selectedCategoryId)) {
+      selectedCategoryId = categories[0]?.id || null;
+      selectedTemplateId = null;
+    }
+    renderCategories();
+    renderTemplates();
+    const tpl = getCurrentTemplate();
+    renderViewer(tpl || null);
+  });
+}
+
+function getCurrentCategory() {
+  return categories.find((c) => c.id === selectedCategoryId) || null;
+}
+
+function getCurrentTemplate() {
+  const cat = getCurrentCategory();
+  if (!cat) return null;
+  return cat.templates.find((t) => t.id === selectedTemplateId) || null;
+}
+
+function renderCategories() {
+  categorySelect.innerHTML = "";
+  for (const cat of categories) {
+    const opt = document.createElement("option");
+    opt.value = cat.id;
+    opt.textContent = cat.name;
+    if (cat.id === selectedCategoryId) opt.selected = true;
+    categorySelect.appendChild(opt);
+  }
+  const disable = categories.length === 0;
+  editCategoryBtn.disabled = disable || !selectedCategoryId;
+  deleteCategoryBtn.disabled = disable || !selectedCategoryId;
+  addTemplateBtn.disabled = disable || !selectedCategoryId;
+}
+
+function renderTemplates() {
+  templatesList.innerHTML = "";
+  const cat = getCurrentCategory();
+  if (!cat) return;
+  for (const tpl of cat.templates) {
+    const item = document.createElement("div");
+    item.className = "template-item";
+    item.addEventListener("click", (e) => {
+      if (e.shiftKey) {
+        // Shift+Click = Copier direct
+        copyText(tpl.text);
+        return;
+      }
+      selectedTemplateId = tpl.id;
+      renderViewer(tpl);
+    });
+
+    const title = document.createElement("p");
+    title.className = "template-item-title";
+    title.textContent = tpl.title;
+    item.appendChild(title);
+
+    const actions = document.createElement("div");
+    actions.className = "template-item-actions";
+
+    const btnOpen = document.createElement("button");
+    btnOpen.className = "btn";
+    btnOpen.textContent = "Ouvrir";
+    btnOpen.addEventListener("click", (e) => {
+      e.stopPropagation();
+      selectedTemplateId = tpl.id;
+      renderViewer(tpl);
+    });
+
+    const btnCopy = document.createElement("button");
+    btnCopy.className = "btn primary";
+    btnCopy.textContent = "Copier";
+    btnCopy.addEventListener("click", (e) => {
+      e.stopPropagation();
+      copyText(tpl.text);
+    });
+
+    const btnEdit = document.createElement("button");
+    btnEdit.className = "btn";
+    btnEdit.textContent = "Modifier";
+    btnEdit.addEventListener("click", (e) => {
+      e.stopPropagation();
+      selectedTemplateId = tpl.id;
+      openTemplateDialog(tpl.id);
+    });
+
+    const btnDelete = document.createElement("button");
+    btnDelete.className = "btn btn-danger";
+    btnDelete.textContent = "Supprimer";
+    btnDelete.addEventListener("click", async (e) => {
+      e.stopPropagation();
+      if (!confirm("Supprimer ce modèle ?")) return;
+      await QRMStorage.removeTemplate(selectedCategoryId, tpl.id);
+      categories = await QRMStorage.getCategories();
+      if (tpl.id === selectedTemplateId) selectedTemplateId = null;
+      renderTemplates();
+      renderViewer(null);
+    });
+
+    actions.appendChild(btnOpen);
+    actions.appendChild(btnCopy);
+    actions.appendChild(btnEdit);
+    actions.appendChild(btnDelete);
+    item.appendChild(actions);
+
+    templatesList.appendChild(item);
+  }
+}
+
+function renderViewer(tpl) {
+  const placeholder = viewer.querySelector(".placeholder");
+  const content = viewer.querySelector(".viewer-content");
+  if (!tpl) {
+    placeholder.classList.remove("hidden");
+    content.classList.add("hidden");
+    return;
+  }
+  placeholder.classList.add("hidden");
+  content.classList.remove("hidden");
+  viewerTitle.textContent = tpl.title;
+  viewerText.value = tpl.text;
+}
+
+async function copyCurrentTemplate() {
+  const tpl = getCurrentTemplate();
+  if (!tpl) return;
+  await copyText(tpl.text);
+}
+
+async function copyText(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    toast("Copié dans le presse-papier");
+  } catch (_) {
+    // Fallback
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand("copy");
+    document.body.removeChild(ta);
+    toast("Copié dans le presse-papier");
+  }
+}
+
+function toast(message) {
+  // simple ephemeral banner
+  const el = document.createElement("div");
+  el.textContent = message;
+  el.style.position = "fixed";
+  el.style.bottom = "10px";
+  el.style.left = "50%";
+  el.style.transform = "translateX(-50%)";
+  el.style.background = "#10b981";
+  el.style.color = "white";
+  el.style.padding = "6px 10px";
+  el.style.borderRadius = "6px";
+  el.style.fontSize = "12px";
+  el.style.zIndex = "9999";
+  document.body.appendChild(el);
+  setTimeout(() => el.remove(), 1200);
+}
+
+async function handleSearchInput() {
+  const q = searchInput.value.trim();
+  if (!q) {
+    searchResults.classList.add("hidden");
+    searchResults.innerHTML = "";
+    return;
+  }
+  const results = await QRMStorage.searchTemplates(q);
+  searchResults.innerHTML = "";
+  searchResults.classList.remove("hidden");
+  for (const r of results) {
+    const row = document.createElement("div");
+    row.className = "search-result";
+    row.innerHTML = `<strong>${escapeHtml(r.title)}</strong><br><small>${escapeHtml(r.categoryName)}</small>`;
+    row.addEventListener("click", () => {
+      selectedCategoryId = r.categoryId;
+      selectedTemplateId = r.templateId;
+      renderCategories();
+      renderTemplates();
+      renderViewer({ title: r.title, text: r.text });
+    });
+    searchResults.appendChild(row);
+  }
+}
+
+function escapeHtml(str) {
+  return (str || "").replace(/[&<>"]|'/g, (c) => {
+    return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#039;" }[c];
+  });
+}
+
+function openCategoryDialog(categoryId) {
+  const editing = Boolean(categoryId);
+  categoryDialogTitle.textContent = editing
+    ? "Modifier la catégorie"
+    : "Nouvelle catégorie";
+  categoryNameInput.value = editing
+    ? (categories.find((c) => c.id === categoryId)?.name || "")
+    : "";
+  categoryDialog.showModal();
+
+  categoryForm.onsubmit = async (e) => {
+    e.preventDefault();
+    const name = categoryNameInput.value.trim();
+    if (!name) return;
+    if (editing) {
+      await QRMStorage.updateCategory(categoryId, name);
+    } else {
+      const cat = await QRMStorage.addCategory(name);
+      selectedCategoryId = cat.id;
+    }
+    categories = await QRMStorage.getCategories();
+    renderCategories();
+    renderTemplates();
+    categoryDialog.close();
+  };
+}
+
+function openTemplateDialog(templateId) {
+  const editing = Boolean(templateId);
+  templateDialogTitle.textContent = editing ? "Modifier le modèle" : "Nouveau modèle";
+  if (editing) {
+    const tpl = getCurrentCategory()?.templates.find((t) => t.id === templateId);
+    templateTitleInput.value = tpl?.title || "";
+    templateTextInput.value = tpl?.text || "";
+  } else {
+    templateTitleInput.value = "";
+    templateTextInput.value = "";
+  }
+  templateDialog.showModal();
+
+  templateForm.onsubmit = async (e) => {
+    e.preventDefault();
+    const title = templateTitleInput.value.trim();
+    const text = templateTextInput.value;
+    if (!title || !text) return;
+    if (editing) {
+      await QRMStorage.updateTemplate(selectedCategoryId, templateId, { title, text });
+    } else {
+      const tpl = await QRMStorage.addTemplate(selectedCategoryId, { title, text });
+      selectedTemplateId = tpl.id;
+    }
+    categories = await QRMStorage.getCategories();
+    renderTemplates();
+    renderViewer(getCurrentTemplate());
+    templateDialog.close();
+  };
+}
+
+// Init
+init();
+

--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,156 @@
+const STORAGE_KEY = "qrm_data_v1";
+
+function getFromStorage(keys) {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(keys, (result) => resolve(result));
+  });
+}
+
+function setToStorage(obj) {
+  return new Promise((resolve) => {
+    chrome.storage.local.set(obj, () => resolve());
+  });
+}
+
+function generateId(prefix = "id") {
+  try {
+    if (crypto && typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID();
+    }
+  } catch (_) {}
+  return (
+    prefix +
+    "_" +
+    Math.random().toString(36).slice(2) +
+    Date.now().toString(36)
+  );
+}
+
+async function getAll() {
+  const data = (await getFromStorage([STORAGE_KEY]))[STORAGE_KEY];
+  if (data && data.categories) {
+    return data;
+  }
+  const seed = {
+    categories: [
+      {
+        id: generateId("cat"),
+        name: "Exemples",
+        templates: [
+          {
+            id: generateId("tpl"),
+            title: "Bienvenue",
+            text:
+              "Bonjour,\nMerci pour votre message. Comment puis-je vous aider ?",
+            updatedAt: Date.now(),
+          },
+        ],
+      },
+    ],
+    updatedAt: Date.now(),
+  };
+  await setToStorage({ [STORAGE_KEY]: seed });
+  return seed;
+}
+
+async function saveAll(data) {
+  data.updatedAt = Date.now();
+  await setToStorage({ [STORAGE_KEY]: data });
+  return data;
+}
+
+export const QRMStorage = {
+  async getCategories() {
+    const data = await getAll();
+    return data.categories;
+  },
+  async addCategory(name) {
+    const data = await getAll();
+    const newCat = { id: generateId("cat"), name, templates: [] };
+    data.categories.push(newCat);
+    await saveAll(data);
+    return newCat;
+  },
+  async updateCategory(categoryId, name) {
+    const data = await getAll();
+    const cat = data.categories.find((c) => c.id === categoryId);
+    if (!cat) return null;
+    cat.name = name;
+    await saveAll(data);
+    return cat;
+  },
+  async removeCategory(categoryId) {
+    const data = await getAll();
+    const idx = data.categories.findIndex((c) => c.id === categoryId);
+    if (idx === -1) return false;
+    data.categories.splice(idx, 1);
+    await saveAll(data);
+    return true;
+  },
+  async addTemplate(categoryId, { title, text }) {
+    const data = await getAll();
+    const cat = data.categories.find((c) => c.id === categoryId);
+    if (!cat) return null;
+    const tpl = { id: generateId("tpl"), title, text, updatedAt: Date.now() };
+    cat.templates.push(tpl);
+    await saveAll(data);
+    return tpl;
+  },
+  async updateTemplate(categoryId, templateId, { title, text }) {
+    const data = await getAll();
+    const cat = data.categories.find((c) => c.id === categoryId);
+    if (!cat) return null;
+    const tpl = cat.templates.find((t) => t.id === templateId);
+    if (!tpl) return null;
+    if (typeof title === "string") tpl.title = title;
+    if (typeof text === "string") tpl.text = text;
+    tpl.updatedAt = Date.now();
+    await saveAll(data);
+    return tpl;
+  },
+  async removeTemplate(categoryId, templateId) {
+    const data = await getAll();
+    const cat = data.categories.find((c) => c.id === categoryId);
+    if (!cat) return false;
+    const idx = cat.templates.findIndex((t) => t.id === templateId);
+    if (idx === -1) return false;
+    cat.templates.splice(idx, 1);
+    await saveAll(data);
+    return true;
+  },
+  async searchTemplates(query) {
+    const q = (query || "").trim().toLowerCase();
+    if (!q) return [];
+    const categories = await this.getCategories();
+    const results = [];
+    for (const cat of categories) {
+      for (const tpl of cat.templates) {
+        if (
+          tpl.title.toLowerCase().includes(q) ||
+          tpl.text.toLowerCase().includes(q) ||
+          cat.name.toLowerCase().includes(q)
+        ) {
+          results.push({
+            categoryId: cat.id,
+            categoryName: cat.name,
+            templateId: tpl.id,
+            title: tpl.title,
+            text: tpl.text,
+          });
+        }
+      }
+    }
+    return results;
+  },
+  onChanged(listener) {
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area !== "local") return;
+      if (STORAGE_KEY in changes) {
+        listener(changes[STORAGE_KEY].newValue);
+      }
+    });
+  },
+};
+
+export default QRMStorage;
+

--- a/style.css
+++ b/style.css
@@ -1,0 +1,195 @@
+:root {
+  --bg: #0f172a;
+  --panel: #111827;
+  --card: #1f2937;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+  --primary: #3b82f6;
+  --danger: #ef4444;
+  --border: #374151;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 420px;
+  height: 640px;
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+
+.title {
+  font-weight: 600;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+#searchInput {
+  flex: 1;
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--text);
+  outline: none;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel);
+}
+
+.btn-group {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.btn {
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.btn:hover { border-color: var(--muted); }
+
+.btn.primary {
+  background: var(--primary);
+  border-color: transparent;
+  color: white;
+}
+
+.btn.btn-danger {
+  background: transparent;
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+label { color: var(--muted); font-size: 12px; }
+
+select, input[type="text"], textarea {
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--text);
+  outline: none;
+}
+
+select { min-width: 160px; }
+
+.main {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  height: calc(100% - 128px);
+}
+
+.list {
+  overflow: auto;
+  border-right: 1px solid var(--border);
+}
+
+.viewer {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.placeholder {
+  margin: auto;
+  color: var(--muted);
+}
+
+.viewer-content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 12px;
+  gap: 8px;
+}
+
+#viewerTitle { margin: 0; font-size: 16px; }
+
+#viewerText {
+  flex: 1;
+  width: 100%;
+  resize: none;
+}
+
+.viewer-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.template-item {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+}
+
+.template-item:hover { background: #0b1220; }
+
+.template-item-title {
+  margin: 0;
+  font-size: 14px;
+}
+
+.template-item-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.search-results {
+  max-height: 160px;
+  overflow: auto;
+  border-bottom: 1px solid var(--border);
+  background: #0b1220;
+}
+
+.search-result {
+  padding: 8px 10px;
+  border-top: 1px solid var(--border);
+  cursor: pointer;
+}
+
+.search-result small { color: var(--muted); }
+
+dialog {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  color: var(--text);
+  background: var(--panel);
+  width: 360px;
+}
+
+dialog::backdrop { background: rgba(0, 0, 0, 0.5); }
+
+dialog form { display: flex; flex-direction: column; gap: 10px; }
+
+menu { display: flex; gap: 8px; justify-content: flex-end; padding: 0; }
+
+.spacer { flex: 1; }
+
+.hidden { display: none; }
+


### PR DESCRIPTION
Add the Quick Reply Manager Chrome extension to enable users to manage and quickly access categorized reply templates.

The extension prioritizes a floating window for quick access, with a fallback to a side panel when available. It attempts to keep the window always-on-top and provides a keyboard shortcut (Alt+Q) for rapid window toggling.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3789374-db50-4c8f-8a99-d7a87b768d36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3789374-db50-4c8f-8a99-d7a87b768d36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

